### PR TITLE
README.md: fix golang.org link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 _Build client side apps with the language you already trust on the backend._
 
-GopherJS compiles [Go code](golang.org) to pure JavaScript code. Its main purpose is to give you the opportunity to write front-end code in Go which will still run in all browsers.
+GopherJS compiles [Go code](http://golang.org) to pure JavaScript code. Its main purpose is to give you the opportunity to write front-end code in Go which will still run in all browsers.
 
 ## Development
 


### PR DESCRIPTION
The link was relative, so when clicking on it from github, the user
was taken to:

```
https://github.com/gopherjs/gopherjs-book/blob/master/golang.org
```

Add the "http://" to take the user to the right website.
